### PR TITLE
add filters option to fetchFirestoreCollection

### DIFF
--- a/src/@ionic-native/plugins/firebase-x/index.ts
+++ b/src/@ionic-native/plugins/firebase-x/index.ts
@@ -896,6 +896,7 @@ export class FirebaseX extends IonicNativePlugin {
   /**
    * Fetches all the documents in the specific collection.
    * @param {string} collection - name of top-level collection to fetch.
+   * @param filters - filters to apply during the fetch of the documents
    * @param {function} success - callback function to call on successfully deleting the document. Will be passed an {object} containing all the documents in the collection,
    * indexed by document ID. If a Firebase collection with that name does not exist or it contains no documents, the object will be empty.
    * @param {function} error - callback function which will be passed a {string} error message as an argument.
@@ -903,6 +904,7 @@ export class FirebaseX extends IonicNativePlugin {
   @Cordova()
   fetchFirestoreCollection(
     collection: string,
+    filters: boolean | Array<Array<any>>,
     success: (docs: any) => void,
     error: (err: string) => void
   ): Promise<any> {


### PR DESCRIPTION
this PR complements https://github.com/ionic-team/ionic-native/pull/3458

The `fetchFirestoreCollection` function now requires a filter to be set. It can be an array or a boolean

```
var collection = "my_collection";
var filters = [
    ['where', 'field', '==', 'value'],
    ['orderBy', 'field', 'desc']
];
FirebasePlugin.fetchFirestoreCollection(collection, filters, function(documents){
    console.log("Successfully fetched collection: "+JSON.stringify(documents));
}, function(error){
    console.error("Error fetching collection: "+error);
});
```
example from https://github.com/dpa99c/cordova-plugin-firebasex#fetchfirestorecollection